### PR TITLE
Add Dream Component with Provider, Local Storage Support, and UI Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
-        "@radix-ui/react-accordion": "^1.2.10",
+        "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-navigation-menu": "^1.2.12",
         "@radix-ui/react-slot": "^1.2.2",
@@ -986,6 +986,12 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
@@ -993,19 +999,19 @@
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accordion": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.10.tgz",
-      "integrity": "sha512-x+URzV1siKmeXPSUIQ22L81qp2eOhjpy3tgteF+zOr4d1u0qJnFuyBF4MoQRhmKP6ivDxlvDAvqaF77gh7DOIw==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.11.tgz",
+      "integrity": "sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.2",
-        "@radix-ui/react-collapsible": "1.1.10",
-        "@radix-ui/react-collection": "1.1.6",
+        "@radix-ui/react-collapsible": "1.1.11",
+        "@radix-ui/react-collection": "1.1.7",
         "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-direction": "1.1.1",
         "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
@@ -1023,10 +1029,77 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.10.tgz",
-      "integrity": "sha512-O2mcG3gZNkJ/Ena34HurA3llPOEA/M4dJtIRMa6y/cknRDC8XY5UZBInKTsUwW5cUue9A4k0wi1XU5fKBzKe1w==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.2",
@@ -1034,7 +1107,7 @@
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-id": "1.1.1",
         "@radix-ui/react-presence": "1.1.4",
-        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
@@ -1049,6 +1122,47 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
-    "@radix-ui/react-accordion": "^1.2.10",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-navigation-menu": "^1.2.12",
     "@radix-ui/react-slot": "^1.2.2",

--- a/src/app/dream/page.tsx
+++ b/src/app/dream/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useDream } from "@/contexts/DreamContext";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+import { FC, useEffect, ReactNode, useState } from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Activity,
+  DollarSign,
+  Users,
+  Calendar,
+  ShieldCheck,
+  Zap,
+  Sun,
+  Coffee,
+  Book,
+  BarChart,
+  Search,
+  Brain,
+  CalendarDays,
+  Briefcase,
+  Clock,
+  Heart,
+  MessageCircle,
+  Star,
+  FlipHorizontal2,
+  RefreshCcw,
+} from "lucide-react";
+import { loadDream, removeDream } from "@/utils/storage";
+
+// Helpers
+const isPrimitive = (value: any): value is string | number | boolean =>
+  ["string", "number", "boolean"].includes(typeof value);
+const isLeafNode = (obj: Record<string, any>): boolean =>
+  Object.values(obj).every((val) => isPrimitive(val));
+
+// Icon map
+const iconMap: Record<string, FC<any>> = {
+  routine: Activity,
+  fear_and_motivation: ShieldCheck,
+  daily_habit: Calendar,
+  career: Briefcase,
+  finance: DollarSign,
+  relationships: Users,
+  daily_routine: Zap,
+  daily_steps: CalendarDays,
+  weekly_steps: Calendar,
+  monthly_steps: Star,
+  morning_routine: Sun,
+  deep_work: Coffee,
+  team_engagement: Users,
+  self_reflection: Book,
+  financial_review: BarChart,
+  investment_research: Search,
+  wealth_mindset_practice: Brain,
+  connection_time: Heart,
+  self_reflection_on_relationships: Book,
+  communication_practice: MessageCircle,
+  strategy_review: Clock,
+  team_development: Users,
+  networking: Users,
+  growth_focused_learning: Book,
+  portfolio_review: BarChart,
+  smart_spending: DollarSign,
+  growth_oriented_networking: Users,
+  financial_education: Book,
+  intentional_date_quality_time: Heart,
+  social_connections: Users,
+  personal_growth_together: Users,
+  team_bonding: Users,
+  visionary_planning: Star,
+  high_impact_project: Briefcase,
+  industry_engagement: Users,
+  mentorship: Users,
+  mentorship_support: Users,
+  family_partner_retreats: Heart,
+  reflect_on_boundaries: ShieldCheck,
+  celebrate_milestones: Star,
+  investment_strategy_update: BarChart,
+  set_financial_milestones: Star,
+  philanthropy_focus: Heart,
+  long_term_financial_vision: Star,
+  exercise: Activity,
+  mindfulness: Book,
+  strategic_planning: Clock,
+  power_blocks: Zap,
+  team_collaboration: Users,
+  breaks: Clock,
+  reflection: Book,
+  wind_down: Heart,
+  prepare_for_tomorrow: Clock,
+  fear_of_not_making_significant_impact: ShieldCheck,
+  fear_of_burnout: ShieldCheck,
+  doubt_about_achieving_financial_freedom: DollarSign,
+  doubt_about_successfully_scaling_investment_portfolio: BarChart,
+  final_motivation_to_push_through: Star,
+  mindset_shift: Brain,
+  motivation: Zap,
+  perspective: Book,
+  remember_your_why: Heart,
+  believe_in_your_ability_to_adapt: ShieldCheck,
+  morning_mindset_ritual: Sun,
+  focused_learning: Book,
+  daily_investment_tracking: BarChart,
+  relationship_building: Users,
+  daily_reflection_and_goal_review: FlipHorizontal2,
+  the_big_picture: Star,
+};
+
+const Dream: FC = () => {
+  const router = useRouter();
+  const { dreamData, setDreamData, userDetails, responseMessage, error } =
+    useDream();
+
+  useEffect(() => {
+    console.log("🚀 context dreamData:", dreamData);
+    if (!dreamData) {
+      const saved = loadDream();
+      console.log("🚀 localStorage dreamResponse:", saved);
+      if (saved) {
+        setDreamData(saved);
+        return; // hydrated, don’t redirect
+      }
+    }
+
+    if ((!dreamData && !loadDream()) || error) {
+      console.info("🔄 No dreamData anywhere—redirecting…");
+      router.push("/playground");
+    }
+  }, [dreamData, error, router, setDreamData]);
+
+  // Only nested payload, filter out id
+  const { id, ...payload } = dreamData?.payload?.payload || {};
+  if (!payload) return null;
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggle = (key: string) => {
+    setExpanded((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const renderNode = (key: string, value: any): ReactNode => {
+    const Icon = iconMap[key];
+    if (isPrimitive(value)) {
+      return (
+        <div className="flex items-center gap-2 mb-2">
+          {Icon && <Icon className="w-5 h-5 text-primary" />}
+          <p className="text-sm">{String(value)}</p>
+        </div>
+      );
+    }
+    if (Array.isArray(value)) {
+      return (
+        <ul className="list-disc list-inside ml-6 mb-2">
+          {value.map((item, idx) => (
+            <li key={idx}>{renderNode(key, item)}</li>
+          ))}
+        </ul>
+      );
+    }
+    if (isLeafNode(value)) {
+      return (
+        <div className="flex flex-col gap-4">
+          {Object.entries(value).map(([k, v]) => {
+            const LeafIcon = iconMap[k];
+            return (
+              <div
+                key={k}
+                className="flex items-start gap-3 p-3 border rounded hover:bg-muted transition"
+              >
+                {LeafIcon && (
+                  <LeafIcon className="w-6 h-6 text-secondary mt-1" />
+                )}
+                <div>
+                  <p className="font-medium capitalize">
+                    {k.replace(/_/g, " ")}
+                  </p>
+                  <p className="text-sm text-muted-foreground">{String(v)}</p>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+    return (
+      <Accordion type="single" collapsible className="space-y-2 w-full">
+        {Object.entries(value).map(([k, v]) => {
+          const NestedIcon = iconMap[k];
+          const isOpen = expanded[k] ?? false;
+          return (
+            <AccordionItem key={k} value={k}>
+              <AccordionTrigger
+                onClick={() => toggle(k)}
+                className="flex justify-between w-full items-center p-2 bg-muted rounded hover:bg-muted/90 transition"
+              >
+                <div className="flex items-center gap-2">
+                  {NestedIcon && (
+                    <NestedIcon className="w-5 h-5 text-primary" />
+                  )}
+                  <span className="capitalize font-medium">
+                    {k.replace(/_/g, " ")}
+                  </span>
+                </div>
+                {isOpen ? (
+                  <ChevronUp className="w-4 h-4" />
+                ) : (
+                  <ChevronDown className="w-4 h-4" />
+                )}
+              </AccordionTrigger>
+              {isOpen && (
+                <AccordionContent className="pl-6">
+                  {renderNode(k, v)}
+                </AccordionContent>
+              )}
+            </AccordionItem>
+          );
+        })}
+      </Accordion>
+    );
+  };
+
+  const analyzeAnotherDream = () => {
+    removeDream();
+    console.info("dreamData removed, redirecting to playground");
+    router.push("/playground");
+  };
+
+  return (
+    <div className="h-full py-8 px-5 sm:px-30 space-y-8">
+      {/* Header Card */}
+      <Card className="p-6 bg-primary/10">
+        <CardTitle className="text-2xl font-semibold flex items-center gap-2">
+          <Activity className="w-6 h-6 text-primary" />
+          Hello, {userDetails?.name || "User"}!
+        </CardTitle>
+        <p className="text-sm text-muted-foreground mt-1">{responseMessage}</p>
+      </Card>
+
+      {/* Body Nodes */}
+      <div className="grid grid-cols-1 gap-6">
+        {Object.entries(payload).map(([section, content]) => {
+          const Icon = iconMap[section];
+          const isOpen = expanded[section] ?? false;
+          return (
+            <Card key={section} className="border hover:shadow-lg transition">
+              <CardHeader className="flex items-center gap-3 p-4">
+                {Icon && <Icon className="w-6 h-6 text-primary" />}
+                <CardTitle className="text-lg font-semibold capitalize">
+                  {section.replace(/_/g, " ")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Accordion type="single" collapsible className="w-full">
+                  <AccordionItem value={section}>
+                    <AccordionTrigger
+                      onClick={() => toggle(section)}
+                      className="flex justify-between w-full items-center p-2 bg-accent rounded hover:bg-accent/90 transition"
+                    >
+                      <span>{isOpen ? "Hide Details" : "View Details"}</span>
+                      {isOpen ? (
+                        <ChevronUp className="w-4 h-4" />
+                      ) : (
+                        <ChevronDown className="w-4 h-4" />
+                      )}
+                    </AccordionTrigger>
+                    {isOpen && (
+                      <AccordionContent className="mt-2">
+                        {renderNode(section, content)}
+                      </AccordionContent>
+                    )}
+                  </AccordionItem>
+                </Accordion>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* Footer Card */}
+      <div className="card-footer mt-10 flex justify-center">
+        <button
+          type="submit"
+          className="
+            bg-green-400 
+            hover:bg-green-600 
+            border 
+            border-green-500 
+            hover:border-green-700 
+            font-bold 
+            transition-all 
+            w-60
+            py-2 
+            px-3 
+            rounded 
+            active:scale-95 
+            flex 
+            gap-2
+          text-gray-100 
+          dark:text-gray-900
+          "
+          onClick={() => analyzeAnotherDream()}
+        >
+          <RefreshCcw className="w-6 h-6 text-gray-100 dark:text-gray-900" />
+          Analyze Another Dream
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default Dream;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import ThemeProvider from "@/components/theme-provider";
-import ThemeToggle from "@/components/theme-toggle";
 import { Navbar } from "@/components/navbar";
+import DreamProvider from "@/contexts/DreamContext";
 
 // Define the types for the theme structure
 interface ThemeColors {
@@ -142,8 +142,10 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <Navbar />
-          {children}
+          <DreamProvider>
+            <Navbar />
+            {children}
+          </DreamProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  );
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+};

--- a/src/contexts/DreamContext.tsx
+++ b/src/contexts/DreamContext.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { createContext, useState, useContext, ReactNode } from "react";
+
+interface DreamData<T = any> {
+  status: boolean;
+  payload: T;
+  message: string;
+  status_code: number;
+}
+
+interface UserDetails {
+  name: string;
+  phone: number;
+  age: number;
+  email: string;
+}
+
+interface DreamContextType {
+  dreamData: DreamData;
+  setDreamData: React.Dispatch<React.SetStateAction<any>>;
+  userDetails: UserDetails;
+  setUserDetails: React.Dispatch<React.SetStateAction<any>>;
+  error: string | null;
+  setError: React.Dispatch<React.SetStateAction<string | null>>;
+  responseMessage: string | null;
+  setResponseMessage: React.Dispatch<React.SetStateAction<string | null>>;
+}
+
+const DreamContext = createContext<DreamContextType | undefined>(undefined);
+
+export const useDream = () => {
+  const context = useContext(DreamContext);
+  if (!context) {
+    throw new Error("useDream must be used within a DreamProvider");
+  }
+  return context;
+};
+
+// Type for provider props
+interface DreamProviderProps {
+  children: ReactNode;
+}
+
+export const DreamProvider: React.FC<DreamProviderProps> = ({ children }) => {
+  const [dreamData, setDreamData] = useState<any>(null);
+  const [userDetails, setUserDetails] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [responseMessage, setResponseMessage] = useState<string | null>(null);
+
+  return (
+    <DreamContext.Provider
+      value={{
+        dreamData,
+        setDreamData,
+        userDetails,
+        setUserDetails,
+        error,
+        setError,
+        responseMessage,
+        setResponseMessage,
+      }}
+    >
+      {children}
+    </DreamContext.Provider>
+  );
+};
+
+export default DreamProvider;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,34 @@
+interface BackendResponse<T = any> {
+  status: boolean;
+  payload: T;
+  message: string;
+  status_code: number;
+}
+
+export const removeDream = () => {
+  try {
+    localStorage.removeItem("dreamResponse");
+    console.log("✅ Removed dreamResponse from localStorage");
+  } catch (e) {
+    console.error("❌ Failed to remove dream from localStorage:", e);
+  }
+};
+
+export const storeDream = (response: BackendResponse) => {
+  try {
+    localStorage.setItem("dreamResponse", JSON.stringify(response));
+    console.log("✅ Stored dreamResponse in localStorage");
+  } catch (e) {
+    console.error("❌ Failed to store in localStorage:", e);
+  }
+};
+
+export const loadDream = (): BackendResponse | null => {
+  const str = localStorage.getItem("dreamResponse");
+  if (!str) return null;
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
* Created `Dream` component
* Created `DreamProvider` for managing dream-related operations
* Added `react-accordion` component in UI and used it in the `Dream` component
* Fixed issues in `fetcher` component
* Added `DreamProvider` to layout
* Wrapped `DreamProvider` inside the `body` element
* Added redirection logic in `Playground` and `Dream` components
* Stored dream data after receiving API response
* Added `Card` component in UI and used it in the `Dream` component
* Created `storage` utility to handle storing, removing, and loading dream data from local storage